### PR TITLE
List page SSR + API, scoped to current user

### DIFF
--- a/__tests__/app/characters/page.test.tsx
+++ b/__tests__/app/characters/page.test.tsx
@@ -1,0 +1,66 @@
+// __tests__/app/characters/page.test.tsx
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+    getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+jest.mock("@/lib/auth", () => ({ authOptions: {} as unknown }));
+
+const mockFindMany = jest.fn();
+jest.mock("@/lib/prisma", () => ({
+    __esModule: true,
+    prisma: {
+        character: {
+            findMany: (...args: unknown[]) => mockFindMany(...args),
+        },
+    },
+}));
+
+const redirect = jest.fn((url: string) => {
+    const e: any = new Error("NEXT_REDIRECT");
+    e.digest = "NEXT_REDIRECT";
+    e.url = url;
+    throw e;
+});
+jest.mock("next/navigation", () => ({ redirect }));
+
+// (Optional) If CharacterList renders heavy JSX, you can stub it:
+jest.mock("@/components/CharacterList", () => ({
+    __esModule: true,
+    default: ({ characters }: { characters: Array<{ id: string; name: string }> }) => {
+        return `LIST:${characters.map((c) => c.id).join(",")}`;
+    },
+}));
+
+import CharactersPage from "@/app/characters/page";
+
+describe("CharactersPage (list)", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("redirects unauthenticated users to sign-in with callbackUrl", async () => {
+        mockGetServerSession.mockResolvedValueOnce(null);
+
+        await expect(CharactersPage()).rejects.toMatchObject({ digest: "NEXT_REDIRECT" });
+        const expected = `/api/auth/signin?callbackUrl=${encodeURIComponent("/characters")}`;
+        expect(redirect).toHaveBeenCalledWith(expected);
+        expect(mockFindMany).not.toHaveBeenCalled();
+    });
+
+    it("renders list for authenticated user", async () => {
+        mockGetServerSession.mockResolvedValueOnce({ user: { id: "user_abc" } });
+        mockFindMany.mockResolvedValueOnce([
+            { id: "c1", name: "Aldra", avatarUrl: null },
+            { id: "c2", name: "Brix", avatarUrl: null },
+        ]);
+
+        const node = await CharactersPage();
+        expect(node).toBeTruthy();
+        expect(mockFindMany).toHaveBeenCalledWith({
+            where: { userId: "user_abc" },
+            orderBy: { name: "asc" },
+            select: { id: true, name: true, avatarUrl: true },
+        });
+    });
+});


### PR DESCRIPTION
- app/characters/page.tsx:
  • SSR fetch via Prisma scoped by userId (not email)
  • Preserves friendly logged-out message with Sign In link (callbackUrl=/characters)
  • Keeps empty-state “No characters yet!” message

- app/api/characters/GET.ts:
  • Returns current user’s characters (401 if unauthenticated)
  • Dynamic/Node runtime, no-store caching

- Tests:
  • Added __tests__/app/characters/page.test.tsx (redirect or friendly message; renders list)
  • Added __tests__/api/characters/get.test.ts (401 unauthenticated, 200 success)
