### PR TITLE
Adds account page with sign-out functionality

### DIFF
--- a/__tests__/app/account/page.test.tsx
+++ b/__tests__/app/account/page.test.tsx
@@ -1,0 +1,59 @@
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+    getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+jest.mock("@/lib/auth", () => ({ authOptions: {} as unknown }));
+
+// Mock redirect behavior like your other page tests
+const redirect = jest.fn((url: string) => {
+    const e: any = new Error("NEXT_REDIRECT");
+    e.digest = "NEXT_REDIRECT";
+    e.url = url;
+    throw e;
+});
+jest.mock("next/navigation", () => ({ redirect }));
+
+// Stub the client-only SignOutButton so server-render test stays simple
+jest.mock("@/components/Account/SignOutButton", () => ({
+    __esModule: true,
+    default: () => <button aria-label="Sign out">Sign Out</button>,
+}));
+
+import AccountPage from "@/app/account/page";
+
+describe("Account page", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("redirects unauthenticated users to sign-in with callback to /account", async () => {
+        mockGetServerSession.mockResolvedValueOnce(null);
+
+        await expect(AccountPage()).rejects.toMatchObject({ digest: "NEXT_REDIRECT" });
+        expect(redirect).toHaveBeenCalledWith(
+            `/api/auth/signin?callbackUrl=${encodeURIComponent("/account")}`
+        );
+    });
+
+    it("renders 'Back to Characters' link and sign-out button for authenticated users", async () => {
+        mockGetServerSession.mockResolvedValueOnce({ user: { id: "user_abc" } });
+
+        const ui = await AccountPage();
+        // Render the returned JSX to assert content
+        // (Using Testing Library render here would require jsdom; this inline
+        // check is sufficient because we mocked SignOutButton.)
+        expect(ui).toBeTruthy();
+
+        // To assert content, mount with RTL:
+        // (If your page tests already use RTL for SSR pages, do that instead.)
+        // For clarity and consistency with your other page tests, here is the RTL approach:
+
+        const { render, screen } = await import("@testing-library/react");
+        render(ui as any);
+
+        const backLink = screen.getByRole("link", { name: /back to your character list/i });
+        expect(backLink).toHaveAttribute("href", "/characters");
+
+        expect(screen.getByRole("button", { name: /sign out/i })).toBeInTheDocument();
+    });
+});

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,0 +1,42 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const runtime = "nodejs";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getUserId } from "@/lib/session";
+import SignOutButton from "@/components/Account/SignOutButton";
+
+export default async function AccountPage() {
+    const session = await getServerSession(authOptions);
+    const userId = getUserId(session);
+
+    if (!userId) {
+        redirect(`/api/auth/signin?callbackUrl=${encodeURIComponent("/account")}`);
+    }
+
+    return (
+        <main className="p-6 max-w-xl mx-auto space-y-6">
+            <header>
+                <h1 className="text-2xl font-bold">Account</h1>
+            </header>
+
+            <nav className="flex gap-3">
+                <Link
+                    href="/characters"
+                    className="underline"
+                    aria-label="Back to your character list"
+                >
+                    ← Back to Characters
+                </Link>
+            </nav>
+
+            <section className="pt-2">
+                <h2 className="text-lg font-semibold mb-2">Session</h2>
+                <SignOutButton />
+            </section>
+        </main>
+    );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
+import HeaderAccountLink from "@/components/HeaderAccountLink";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,6 +30,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>
+          <HeaderAccountLink />
           {children}
         </Providers>      </body>
     </html>

--- a/components/Account/SignOutButton.tsx
+++ b/components/Account/SignOutButton.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import type { ReactElement } from "react";
+
+export default function SignOutButton(): ReactElement {
+    return (
+        <button
+            type="button"
+            onClick={() => signOut({ callbackUrl: "/" })}
+            className="px-3 py-2 rounded border shadow-sm"
+            aria-label="Sign out"
+        >
+            Sign Out
+        </button>
+    );
+}

--- a/components/HeaderAccountLink/HeaderAccountLink.test.tsx
+++ b/components/HeaderAccountLink/HeaderAccountLink.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import HeaderAccountLink from "./HeaderAccountLink";
+
+// Mocks
+jest.mock("next-auth/react", () => ({
+    useSession: jest.fn(),
+}));
+jest.mock("next/navigation", () => ({
+    usePathname: jest.fn(),
+}));
+
+const { useSession } = require("next-auth/react");
+const { usePathname } = require("next/navigation");
+
+function setAuth(
+    status: "authenticated" | "unauthenticated" | "loading" = "authenticated"
+) {
+    (useSession as jest.Mock).mockReturnValue({ status });
+}
+
+function setPath(pathname: string) {
+    (usePathname as jest.Mock).mockReturnValue(pathname);
+}
+
+describe("HeaderAccountLink", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("renders nothing when unauthenticated", () => {
+        setAuth("unauthenticated");
+        setPath("/characters");
+
+        render(<HeaderAccountLink />);
+        expect(screen.queryByRole("link", { name: /account/i })).toBeNull();
+    });
+
+    it("hides on root '/' when authenticated", () => {
+        setAuth("authenticated");
+        setPath("/");
+
+        render(<HeaderAccountLink />);
+        expect(screen.queryByRole("link", { name: /account/i })).toBeNull();
+    });
+
+    it("shows on non-root pages when authenticated", () => {
+        setAuth("authenticated");
+        setPath("/characters");
+
+        render(<HeaderAccountLink />);
+        const link = screen.getByRole("link", { name: /go to account settings/i });
+        expect(link).toHaveAttribute("href", "/account");
+        expect(link).toHaveTextContent(/account/i);
+    });
+
+    it("hides on '/account' when authenticated", () => {
+        setAuth("authenticated");
+        setPath("/account");
+
+        render(<HeaderAccountLink />);
+        expect(screen.queryByRole("link", { name: /account/i })).toBeNull();
+    });
+
+    it("hides on nested '/account/*' when authenticated", () => {
+        setAuth("authenticated");
+        setPath("/account/security");
+
+        render(<HeaderAccountLink />);
+        expect(screen.queryByRole("link", { name: /account/i })).toBeNull();
+    });
+});

--- a/components/HeaderAccountLink/HeaderAccountLink.tsx
+++ b/components/HeaderAccountLink/HeaderAccountLink.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import { usePathname } from "next/navigation";
+import type { ReactElement } from "react";
+
+export default function HeaderAccountLink(): ReactElement | null {
+    const { status } = useSession();
+    const pathname = usePathname() || "/";
+
+    // Only show when authenticated
+    if (status !== "authenticated") return null;
+
+    // Hide on root and on /account (and any subpaths)
+    const isRoot = pathname === "/";
+    const isAccount = pathname === "/account" || pathname.startsWith("/account/");
+    if (isRoot || isAccount) return null;
+
+    return (
+        <div className="fixed top-4 right-4 z-50">
+            <Link
+                href="/account"
+                className="text-sm underline bg-white/80 backdrop-blur px-2 py-1 rounded"
+                aria-label="Go to account settings"
+            >
+                Account
+            </Link>
+        </div>
+    );
+}

--- a/components/HeaderAccountLink/index.ts
+++ b/components/HeaderAccountLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HeaderAccountLink";


### PR DESCRIPTION
Introduces an account page accessible to authenticated users, displaying a sign-out button and a link back to the character list.

Implements a header link to the account page, conditionally rendered based on authentication status and current route.
