### PR TITLE
Adds roll workspace with actions and modifiers

### DIFF
--- a/app/characters/[id]/page.tsx
+++ b/app/characters/[id]/page.tsx
@@ -9,6 +9,8 @@ import { prisma } from "@/lib/prisma";
 import { getUserId } from "@/lib/session";
 import type { ReactElement } from "react";
 import CharacterDetails from "@/components/CharacterDetails";
+import RollWorkspace from "@/components/roll/RollWorkspace";
+
 
 type CharacterPageProps = {
     // Next.js may provide async params; await before using.
@@ -33,5 +35,10 @@ export default async function CharacterPage({ params }: CharacterPageProps): Pro
         notFound();
     }
 
-    return <CharacterDetails character={character} />;
+    return (
+        <main className="px-4 py-4 md:px-6 lg:px-8">
+            <CharacterDetails character={character} />
+            <RollWorkspace characterId={id} />
+        </main>
+    );
 }

--- a/components/roll/HistoryPane.tsx
+++ b/components/roll/HistoryPane.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect } from "react";
+
+export default function HistoryPane({ onHasHistoryChange }: { onHasHistoryChange?: (has: boolean) => void }) {
+    // For now, there is no history until M5 implement, then true/false will be passed to onHasHistoryChange
+    useEffect(() => {
+        onHasHistoryChange?.(false);
+    }, [onHasHistoryChange]);
+
+    return (
+        <div className="min-h-full">
+            <div className="text-center text-slate-400 mt-8">
+                <p className="text-sm">No rolls yet.</p>
+                <p className="text-xs mt-1">Use “Roll Them Bones” to create your first Action Group.</p>
+            </div>
+        </div>
+    );
+}

--- a/components/roll/ReadyPane.tsx
+++ b/components/roll/ReadyPane.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { useLongPress } from "./useLongPress";
+import type {
+    ActionRecord,
+    ModifierRecord,
+    CharacterPreferences,
+    Tally,
+} from "./types";
+import { isAddTally, isAdvTally } from "./types";
+
+type Props = {
+    preferences: CharacterPreferences;
+    actions: ActionRecord[];
+    modifiers: ModifierRecord[];
+    // selection state
+    tallies: Record<string, Tally>; // actionId -> tally
+    setTallies: (updater: (prev: Record<string, Tally>) => Record<string, Tally>) => void;
+    selectedPerActionMods: Record<string, boolean>;
+    setSelectedPerActionMods: (updater: (prev: Record<string, boolean>) => Record<string, boolean>) => void;
+    selectedPerTurnMods: Record<string, boolean>;
+    setSelectedPerTurnMods: (updater: (prev: Record<string, boolean>) => Record<string, boolean>) => void;
+};
+
+export default function ReadyPane({
+    preferences,
+    actions,
+    modifiers,
+    tallies,
+    setTallies,
+    selectedPerActionMods,
+    setSelectedPerActionMods,
+    selectedPerTurnMods,
+    setSelectedPerTurnMods,
+}: Props) {
+    const followsAdv = preferences.followsAdvantageRules;
+
+    // Alphabetical sort; favorites are not pinned
+    const sortedActions = useMemo(
+        () => [...actions].sort((a, b) => a.name.localeCompare(b.name)),
+        [actions]
+    );
+    const perActionMods = useMemo(
+        () => modifiers.filter(m => m.factorsJson.eachAttack).sort((a, b) => a.name.localeCompare(b.name)),
+        [modifiers]
+    );
+    const perTurnMods = useMemo(
+        () => modifiers.filter(m => !m.factorsJson.eachAttack).sort((a, b) => a.name.localeCompare(b.name)),
+        [modifiers]
+    );
+
+    // Preselect favorites & init tallies
+    useEffect(() => {
+        setTallies(prev => {
+            const next = { ...prev };
+            for (const a of actions) {
+                if (!(a.id in next)) {
+                    next[a.id] = followsAdv ? { disadv: 0, normal: 0, adv: 0 } : { add: 0 };
+                }
+            }
+            return next;
+        });
+        setSelectedPerActionMods(prev => {
+            const next = { ...prev };
+            for (const m of perActionMods) if (next[m.id] === undefined) next[m.id] = !!m.favorite;
+            return next;
+        });
+        setSelectedPerTurnMods(prev => {
+            const next = { ...prev };
+            for (const m of perTurnMods) if (next[m.id] === undefined) next[m.id] = !!m.favorite;
+            return next;
+        });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [actions, perActionMods, perTurnMods, followsAdv]);
+
+    function inc(actionId: string, bucket: "disadv" | "normal" | "adv" | "add") {
+        setTallies(prev => {
+            const curr = prev[actionId];
+            if (!curr) return prev;
+            if (isAddTally(curr)) {
+                const next = Math.min(10, curr.add + 1);
+                return { ...prev, [actionId]: { add: bucket === "add" ? next : curr.add } };
+            }
+            if (isAdvTally(curr)) {
+                const next = { ...curr };
+                if (bucket === "disadv") next.disadv = Math.min(10, next.disadv + 1);
+                if (bucket === "normal") next.normal = Math.min(10, next.normal + 1);
+                if (bucket === "adv") next.adv = Math.min(10, next.adv + 1);
+                return { ...prev, [actionId]: next };
+            }
+            return prev;
+        });
+    }
+
+    function dec(actionId: string, bucket: "disadv" | "normal" | "adv" | "add") {
+        setTallies(prev => {
+            const curr = prev[actionId];
+            if (!curr) return prev;
+            if (isAddTally(curr)) {
+                const next = Math.max(0, curr.add - 1);
+                return { ...prev, [actionId]: { add: bucket === "add" ? next : curr.add } };
+            }
+            if (isAdvTally(curr)) {
+                const next = { ...curr };
+                if (bucket === "disadv") next.disadv = Math.max(0, next.disadv - 1);
+                if (bucket === "normal") next.normal = Math.max(0, next.normal - 1);
+                if (bucket === "adv") next.adv = Math.max(0, next.adv - 1);
+                return { ...prev, [actionId]: next };
+            }
+            return prev;
+        });
+    }
+
+    const LongPressBtn = ({
+        onClick,
+        onLongPress,
+        children,
+        className = "",
+        title,
+    }: {
+        onClick: () => void;
+        onLongPress: () => void;
+        children: React.ReactNode;
+        className?: string;
+        title?: string;
+    }) => {
+        const lp = useLongPress({ onLongPress, delay: 400 });
+        return (
+            <button
+                className={`rounded-2xl px-3 py-2 shadow-sm border border-slate-600/60 bg-slate-800/60 hover:bg-slate-800 ${className}`}
+                onClick={onClick}
+                onContextMenu={(e) => { e.preventDefault(); onLongPress(); }}
+                title={title}
+                {...lp}
+            >
+                {children}
+            </button>
+        );
+    };
+
+    return (
+        <div className="min-h-full flex flex-col">
+            {/* Actions */}
+            <section className="mb-6">
+                <h2 className="text-lg font-semibold mb-2">Actions</h2>
+                <ul className="space-y-3">
+                    {sortedActions.map((a) => {
+                        const t = tallies[a.id];
+                        const subtitle = buildActionSubtitle(a);
+                        return (
+                            <li key={a.id} className="border border-slate-700 rounded-2xl p-3 bg-slate-900/40">
+                                <div className="flex items-start justify-between gap-3">
+                                    <div>
+                                        <div className="text-base font-medium">{a.name}</div>
+                                        {subtitle && <div className="text-xs text-slate-400 mt-0.5">{subtitle}</div>}
+                                        {/* Conditions badges */}
+                                        <div className="mt-1 flex gap-2 flex-wrap text-[11px] text-slate-300">
+                                            {a.factorsJson.conditions?.wielding && (
+                                                <span className="px-2 py-0.5 rounded-full border border-slate-700">
+                                                    {a.factorsJson.conditions.wielding === "weapon" ? "Weapon" : "Unarmed"}
+                                                </span>
+                                            )}
+                                            {a.factorsJson.conditions?.distance && (
+                                                <span className="px-2 py-0.5 rounded-full border border-slate-700 capitalize">
+                                                    {a.factorsJson.conditions.distance}
+                                                </span>
+                                            )}
+                                            {a.factorsJson.conditions?.spell && (
+                                                <span className="px-2 py-0.5 rounded-full border border-slate-700">Spell</span>
+                                            )}
+                                        </div>
+                                    </div>
+
+                                    {/* Tally buttons */}
+                                    <div className="flex items-center gap-2 shrink-0">
+                                        {!t ? null : isAddTally(t) ? (
+                                            <div className="flex items-center gap-2">
+                                                <LongPressBtn
+                                                    onClick={() => inc(a.id, "add")}
+                                                    onLongPress={() => dec(a.id, "add")}
+                                                    title="Tap to add; long-press or right-click to remove"
+                                                >
+                                                    Add {t.add}
+                                                </LongPressBtn>
+                                            </div>
+                                        ) : isAdvTally(t) ? (
+                                            <div className="flex items-center gap-2">
+                                                <LongPressBtn
+                                                    onClick={() => inc(a.id, "disadv")}
+                                                    onLongPress={() => dec(a.id, "disadv")}
+                                                    title="Tap to add; long-press or right-click to remove"
+                                                >
+                                                    Disadv {t.disadv}
+                                                </LongPressBtn>
+                                                <LongPressBtn
+                                                    onClick={() => inc(a.id, "normal")}
+                                                    onLongPress={() => dec(a.id, "normal")}
+                                                    title="Tap to add; long-press or right-click to remove"
+                                                >
+                                                    Normal {t.normal}
+                                                </LongPressBtn>
+                                                <LongPressBtn
+                                                    onClick={() => inc(a.id, "adv")}
+                                                    onLongPress={() => dec(a.id, "adv")}
+                                                    title="Tap to add; long-press or right-click to remove"
+                                                >
+                                                    Adv {t.adv}
+                                                </LongPressBtn>
+                                            </div>
+                                        ) : null}
+                                    </div>
+                                </div>
+
+                                {/* Action damage preview (verbose list, no grouping/totals) */}
+                                {a.factorsJson.damage?.length > 0 && (
+                                    <ul className="mt-3 text-sm text-slate-200 space-y-1">
+                                        {a.factorsJson.damage.map((d, i) => (
+                                            <li key={i}>
+                                                <span className="font-medium">
+                                                    {formatDamageLineType(d.type)}
+                                                </span>{" "}
+                                                {formatDamageDetails(d)}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </li>
+                        );
+                    })}
+                </ul>
+            </section>
+
+            {/* Modifiers */}
+            <section className="mb-32">
+                <h2 className="text-lg font-semibold mb-2">Action Modifiers</h2>
+
+                <h3 className="text-sm text-slate-300 mb-1">Per Action</h3>
+                <ul className="space-y-2 mb-4">
+                    {perActionMods.map((m) => (
+                        <li key={m.id} className="flex items-center justify-between border border-slate-700 rounded-xl p-2 bg-slate-900/40">
+                            <label className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    className="size-4 accent-slate-300"
+                                    checked={!!selectedPerActionMods[m.id]}
+                                    onChange={(e) =>
+                                        setSelectedPerActionMods(prev => ({ ...prev, [m.id]: e.target.checked }))
+                                    }
+                                />
+                                <span className="text-sm">{m.name}</span>
+                            </label>
+                            <span className="text-[11px] text-slate-400">each attack</span>
+                        </li>
+                    ))}
+                </ul>
+
+                <h3 className="text-sm text-slate-300 mb-1">Per Turn</h3>
+                <ul className="space-y-2">
+                    {perTurnMods.map((m) => (
+                        <li key={m.id} className="flex items-center justify-between border border-slate-700 rounded-xl p-2 bg-slate-900/40">
+                            <label className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    className="size-4 accent-slate-300"
+                                    checked={!!selectedPerTurnMods[m.id]}
+                                    onChange={(e) =>
+                                        setSelectedPerTurnMods(prev => ({ ...prev, [m.id]: e.target.checked }))
+                                    }
+                                />
+                                <span className="text-sm">{m.name}</span>
+                            </label>
+                            <span className="text-[11px] text-slate-400">per turn</span>
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        </div>
+    );
+}
+
+function buildActionSubtitle(a: ActionRecord): string {
+    const th = a.factorsJson.toHit;
+    const parts: string[] = [];
+    if (th) {
+        const stat = th.static ?? 0;
+        const sign = th.signStatic ?? 1;
+        const dice = th.dice?.map(d => `${d.count}d${d.size}`).join(" + ");
+        const hitBits = [
+            dice ? dice : null,
+            stat ? `${sign > 0 ? "+" : "-"} ${Math.abs(stat)}` : null,
+        ].filter(Boolean);
+        if (hitBits.length) parts.push(`Attack: ${hitBits.join(" + ")}`);
+    }
+    const dmg = a.factorsJson.damage ?? [];
+    for (const d of dmg) {
+        const dice = d.dice?.map(x => `${x.count}d${x.size}`).join(" + ");
+        const stat = d.static ?? 0;
+        const sign = d.signStatic ?? 1;
+        const bits = [
+            dice ? dice : null,
+            stat ? `${sign > 0 ? "+" : "-"} ${Math.abs(stat)}` : null,
+        ].filter(Boolean);
+        const type = formatDamageLineType(d.type);
+        if (bits.length) parts.push(`${bits.join(" + ")} ${type}`);
+    }
+    return parts.join(" | ");
+}
+
+function formatDamageLineType(type: string | null) {
+    return type === null ? "None (base)" : type;
+}
+
+function formatDamageDetails(d: NonNullable<ActionRecord["factorsJson"]["damage"]>[number]) {
+    const dice = d.dice?.map(x => `${x.count}d${x.size}`).join(" + ");
+    const stat = d.static ?? 0;
+    const sign = d.signStatic ?? 1;
+    const bits = [
+        dice ? dice : null,
+        stat ? `${sign > 0 ? "+" : "-"} ${Math.abs(stat)}` : null,
+    ].filter(Boolean);
+    return bits.length ? bits.join(" + ") : "—";
+}

--- a/components/roll/RollWorkspace.tsx
+++ b/components/roll/RollWorkspace.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import ReadyPane from "./ReadyPane";
+import HistoryPane from "./HistoryPane";
+import type {
+    ActionRecord,
+    ModifierRecord,
+    CharacterPreferences,
+    CharacterRecord,
+    Tally,
+} from "./types";
+import { emptyTally as makeEmptyTally } from "./types";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Props = { characterId: string };
+
+export default function RollWorkspace({ characterId }: Props) {
+    const router = useRouter();
+    const search = useSearchParams();
+    const mode = (search.get("mode") ?? "ready") as "ready" | "history" | string;
+
+    // Data
+    const [character, setCharacter] = useState<CharacterRecord | null>(null);
+    const [actions, setActions] = useState<ActionRecord[]>([]);
+    const [modifiers, setModifiers] = useState<ModifierRecord[]>([]);
+
+    // Selection state
+    const [tallies, setTallies] = useState<Record<string, Tally>>({});
+    const [selectedPerActionMods, setSelectedPerActionMods] = useState<Record<string, boolean>>({});
+    const [selectedPerTurnMods, setSelectedPerTurnMods] = useState<Record<string, boolean>>({});
+
+    // History presence (enables button even when no tallies)
+    const [hasHistory, setHasHistory] = useState(false);
+
+    const prefs: CharacterPreferences = useMemo(() => {
+        const p = character?.preferences;
+        return {
+            followsAdvantageRules: p?.followsAdvantageRules ?? true,
+            critRules: p?.critRules ?? "5e-double-damage-dice",
+            critThreshold: p?.critThreshold ?? 20,
+            uniqueDamageTypes: p?.uniqueDamageTypes ?? [],
+        };
+    }, [character]);
+
+    // Fetch
+    useEffect(() => {
+        let alive = true;
+        (async () => {
+            const [charRes, actRes, modRes] = await Promise.all([
+                fetch(`/api/characters/${characterId}`, { cache: "no-store" }),
+                fetch(`/api/characters/${characterId}/actions`, { cache: "no-store" }),
+                fetch(`/api/characters/${characterId}/action-modifiers`, { cache: "no-store" }),
+            ]);
+            if (!alive) return;
+            if (charRes.ok) setCharacter((await charRes.json()).character ?? null);
+            if (actRes.ok) setActions((await actRes.json()).actions ?? []);
+            if (modRes.ok) setModifiers((await modRes.json()).modifiers ?? []);
+        })();
+        return () => { alive = false; };
+    }, [characterId]);
+
+    // Initialize tallies for any new actions
+    useEffect(() => {
+        setTallies(prev => {
+            const next = { ...prev };
+            for (const a of actions) {
+                if (!(a.id in next)) next[a.id] = makeEmptyTally(prefs.followsAdvantageRules);
+            }
+            return next;
+        });
+    }, [actions, prefs.followsAdvantageRules]);
+
+    // Scroll-snap: switch mode when the visible pane changes (mobile)
+    const scrollerRef = useRef<HTMLDivElement>(null);
+    function setMode(next: "ready" | "history") {
+        const params = new URLSearchParams(search.toString());
+        params.set("mode", next);
+        router.replace(`?${params.toString()}`);
+        const node = scrollerRef.current;
+        if (!node) return;
+        const index = next === "ready" ? 0 : 1;
+        node.scrollTo({ left: index * node.clientWidth, behavior: "smooth" });
+    }
+
+    function onScrollSnap() {
+        const node = scrollerRef.current;
+        if (!node) return;
+        const idx = Math.round(node.scrollLeft / node.clientWidth);
+        const next = idx === 0 ? "ready" : "history";
+        if (next !== mode) setMode(next);
+    }
+
+    // Enable button if any tallies OR if History reports content
+    const hasAnyTallies = useMemo(() => {
+        return Object.values(tallies).some(t => ("add" in t ? t.add : (t as any).adv + (t as any).normal + (t as any).disadv) > 0);
+    }, [tallies]);
+    const canRoll = hasHistory || hasAnyTallies;
+
+    return (
+        <div className="w-full">
+            <div
+                ref={scrollerRef}
+                className="relative w-full overflow-x-auto md:overflow-x-visible snap-x snap-mandatory md:snap-none flex md:grid md:grid-cols-2 gap-0"
+                onScroll={() => {
+                    clearTimeout((onScrollSnap as any)._t);
+                    (onScrollSnap as any)._t = setTimeout(onScrollSnap, 120);
+                }}
+            >
+                {/* Ready column */}
+                <section className="snap-start shrink-0 w-full md:w-auto md:pr-4">
+                    <h1 className="text-xl md:text-2xl font-semibold mb-3 md:mb-4">Ready an Action</h1>
+
+                    <ReadyPane
+                        preferences={prefs}
+                        actions={actions}
+                        modifiers={modifiers}
+                        tallies={tallies}
+                        setTallies={setTallies}
+                        selectedPerActionMods={selectedPerActionMods}
+                        setSelectedPerActionMods={setSelectedPerActionMods}
+                        selectedPerTurnMods={selectedPerTurnMods}
+                        setSelectedPerTurnMods={setSelectedPerTurnMods}
+                    />
+
+                    {/* Sticky footer — centered & wider on desktop, full-width on mobile */}
+                    <div className="sticky bottom-2 md:bottom-4 pt-2 pb-1 bg-gradient-to-t from-slate-950/80 via-slate-950/30 to-transparent">
+                        <div className="flex justify-center">
+                            <button
+                                disabled={!canRoll}
+                                onClick={() => setMode("history")}
+                                className={`rounded-2xl px-5 py-3 font-semibold border transition ${canRoll
+                                    ? "bg-slate-200 text-slate-900 border-slate-300 hover:bg-white"
+                                    : "bg-slate-800 text-slate-500 border-slate-700 cursor-not-allowed"
+                                    } w-full md:w-3/4 lg:w-1/2 max-w-xl mx-auto`}
+                                title={
+                                    canRoll
+                                        ? "Switch to History"
+                                        : "Add at least one tally to enable (or view History when rolls exist)"
+                                }
+                            >
+                                Roll Them Bones
+                            </button>
+                        </div>
+                    </div>
+                </section>
+
+                {/* History column */}
+                <section className="snap-start shrink-0 w-full md:w-auto md:pl-4">
+                    <h1 className="text-xl md:text-2xl font-semibold mb-3 md:mb-4">Roll History</h1>
+                    <HistoryPane onHasHistoryChange={setHasHistory} />
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/components/roll/types.ts
+++ b/components/roll/types.ts
@@ -1,0 +1,96 @@
+export type DieSize = 4 | 6 | 8 | 10 | 12 | 20 | 100;
+export type Signed = 1 | -1;
+
+export type ToHitDie = {
+  count: number;
+  size: DieSize;
+  signDice?: Signed;
+  canCrit?: boolean;
+};
+
+export type ActionFactors = {
+  conditions?: {
+    wielding?: "weapon" | "unarmed";
+    distance?: "melee" | "ranged";
+    spell?: boolean;
+  };
+  toHit?: {
+    static?: number;
+    signStatic?: Signed;
+    dice?: ToHitDie[];
+  };
+  damage: Array<{
+    type: string | null; // null = "None (base)" → inherits first action type
+    static?: number;
+    signStatic?: Signed;
+    dice?: Array<{ count: number; size: DieSize; signDice?: Signed }>;
+  }>;
+  favorite?: boolean;
+};
+
+export type ActionModifierFactors = {
+  eachAttack: boolean; // true = per-action, false = per-turn
+  conditions?: ActionFactors["conditions"];
+  attackImpact?: {
+    static?: number;
+    signStatic?: Signed;
+    dice?: Array<{ count: number; size: DieSize; signDice?: Signed }>;
+  };
+  damage: Array<{
+    type: string | null; // null allowed ONLY when eachAttack=true
+    source?: string; // <=18 chars; shows when type is null
+    static?: number;
+    signStatic?: Signed;
+    dice?: Array<{ count: number; size: DieSize; signDice?: Signed }>;
+  }>;
+  favorite?: boolean;
+};
+
+export type CharacterPreferences = {
+  followsAdvantageRules: boolean;
+  critRules: "5e-double-damage-dice" | null;
+  critThreshold: number; // 0–20
+  uniqueDamageTypes: string[];
+};
+
+export type CharacterRecord = {
+  id: string;
+  name?: string | null;
+  preferences?: CharacterPreferences | null;
+};
+
+export type ActionRecord = {
+  id: string;
+  characterId: string;
+  name: string;
+  favorite: boolean;
+  factorsJson: ActionFactors;
+};
+
+export type ModifierRecord = {
+  id: string;
+  characterId: string;
+  name: string;
+  favorite: boolean;
+  factorsJson: ActionModifierFactors;
+};
+
+// ----- Tally union + guards -----
+export type AddTally = { add: number };
+export type AdvTally = { disadv: number; normal: number; adv: number };
+export type Tally = AddTally | AdvTally;
+
+export function isAddTally(t: Tally): t is AddTally {
+  return (t as AddTally).add !== undefined;
+}
+export function isAdvTally(t: Tally): t is AdvTally {
+  return (
+    (t as AdvTally).disadv !== undefined &&
+    (t as AdvTally).normal !== undefined &&
+    (t as AdvTally).adv !== undefined
+  );
+}
+
+export function emptyTally(followsAdvantageRules: boolean): Tally {
+  return followsAdvantageRules ? { disadv: 0, normal: 0, adv: 0 } : { add: 0 };
+}

--- a/components/roll/useLongPress.ts
+++ b/components/roll/useLongPress.ts
@@ -1,0 +1,31 @@
+"use client";
+import { useRef, useCallback } from "react";
+
+type Options = { onLongPress: () => void; delay?: number };
+
+export function useLongPress({ onLongPress, delay = 400 }: Options) {
+  const timer = useRef<number | null>(null);
+
+  const onPointerDown = useCallback(() => {
+    if (timer.current) window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(() => {
+      onLongPress();
+      timer.current && window.clearTimeout(timer.current);
+      timer.current = null;
+    }, delay);
+  }, [onLongPress, delay]);
+
+  const clear = useCallback(() => {
+    if (timer.current) {
+      window.clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }, []);
+
+  return {
+    onPointerDown,
+    onPointerUp: clear,
+    onPointerLeave: clear,
+    onPointerCancel: clear,
+  };
+}


### PR DESCRIPTION
Implements a roll workspace for character pages, allowing users to manage actions and modifiers.

Introduces a 'Ready' pane for selecting actions and modifiers, along with a 'History' pane to display roll history (feature incomplete).

Adds client-side logic for managing action tallies, modifier selections, and fetching character data.

Includes long-press functionality for incrementing/decrementing action tallies.
